### PR TITLE
Added buttons for shifting plot windows by a fixed amt of time

### DIFF
--- a/MagPy4.py
+++ b/MagPy4.py
@@ -158,7 +158,7 @@ class MagPy4Window(QtWidgets.QMainWindow, MagPy4UI):
     def shiftWindow(self, direction):
         winWidth = abs(self.tE - self.tO) # Amt of time currently displayed
         # TODO: Method for user to set shift amount, set to fixed value for now
-        shiftAmt = winWidth/2
+        shiftAmt = winWidth/3
 
         if direction == 'L':
             shiftAmt = shiftAmt * (-1) # Shift amt is negative if moving left

--- a/MagPy4UI.py
+++ b/MagPy4UI.py
@@ -146,12 +146,14 @@ class MagPy4UI(object):
 
         # Create buttons for moving plot windows L or R by a fixed amt
         # TODO: Change button size, location, etc.
-        shftWinLayout = QtWidgets.QGridLayout()
+        shftWinLayout = QtWidgets.QHBoxLayout()
         self.mvRgtBtn = QtWidgets.QPushButton('&Shift Right', window)
         self.mvLftBtn = QtWidgets.QPushButton('&Shift Left', window)
-        btnRw, btnCol = 0, 0
-        shftWinLayout.addWidget(self.mvRgtBtn, btnRw, btnCol+1, 1, 1)
-        shftWinLayout.addWidget(self.mvLftBtn, btnRw, btnCol, 1, 1)
+        self.mvLftBtn.setShortcut('Left')
+        self.mvRgtBtn.setShortcut('Right')
+        shftWinLayout.addWidget(self.mvLftBtn, 1)
+        shftWinLayout.addWidget(self.mvRgtBtn, 1)
+        shftWinLayout.addStretch(2)
         layout.addLayout(shftWinLayout)
 
          # update slider tick amount and timers and labels and stuff based on new file


### PR DESCRIPTION
Can also be controlled with left and right keys.
Currently only shifts window by 1/3 of the amount of time being looked at.
Not sure about buttons' appearances/placement or whether we should set up a way for the user to set the shift amount.
Could also just get rid of buttons and leave keyboard shortcuts?